### PR TITLE
Fix url for details.

### DIFF
--- a/apps/urls.py
+++ b/apps/urls.py
@@ -19,7 +19,7 @@ urlpatterns = patterns(
     ),
 
     url(
-        r'^apps/(?P<pk>\d)/$',
+        r'^apps/(?P<pk>\d+)/$',
         DetailVersionedApp.as_view(),
         name="details_versioned_app"
     ),


### PR DESCRIPTION
Hi! Due to incorrect regular expression in details url it's not possible to get app details with id > 9. This local change fixes this. Thanks.
